### PR TITLE
No Rc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ blake3 = "1.0"
 rand = "0.8"
 sha2 = "0.10"
 hmac = "0.12"
+rayon = "1.5.2"
 
 [[bench]]
 name = "benchmark"


### PR DESCRIPTION
This resolves #15.

This PR contains 3 commits. Only the first commit is needed to remove the `Rc` shared pointer. 

The second commit is a possible improvement that removes `HashInner` because it no longer appears to be needed. The third commit is a test that shows that  _sthash_ can be used in parallel with Rayon.

