### PR TITLE
Arc replaces Rc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ blake3 = "1.0"
 rand = "0.8"
 sha2 = "0.10"
 hmac = "0.12"
+rayon = "1.5.2"
 
 [[bench]]
 name = "benchmark"

--- a/src/sthash.rs
+++ b/src/sthash.rs
@@ -1,6 +1,6 @@
 use super::nhpoly1305;
 use byteorder::{ByteOrder, LittleEndian};
-use std::rc::Rc;
+use std::sync::Arc;
 use tiny_keccak::{CShake, Hasher as _, Kmac};
 
 const KMAC_KEY_BYTES: usize = 32;
@@ -27,7 +27,7 @@ struct HashInner {
 /// A `Hasher` can be reused to compute multiple hashes using the same key
 #[derive(Clone)]
 pub struct Hasher {
-    inner: Rc<HashInner>,
+    inner: Arc<HashInner>,
 }
 
 impl Hasher {
@@ -61,7 +61,7 @@ impl Hasher {
         let kmac_key = &key.0[..KMAC_KEY_BYTES];
         let st_kmac = Kmac::v128(kmac_key, personalization.unwrap_or_default());
         Hasher {
-            inner: Rc::new(HashInner { key, st_kmac }),
+            inner: Arc::new(HashInner { key, st_kmac }),
         }
     }
 }


### PR DESCRIPTION
This PR resolves #15.

The PR contains two commits:

- Replace `Rc` with `Arc` so that the Hasher can be cloned and sent to different threads.
- A test to demonstrate _sthash_ working with the Rayon crate.

The change to `Arc` did not change the benchmark results when I ran them. 